### PR TITLE
Feature/add sessionid to events

### DIFF
--- a/models/events/snowplow_enriched_events.sql
+++ b/models/events/snowplow_enriched_events.sql
@@ -24,7 +24,6 @@ WITH events AS (
 
       e.domain_userid,
       e.domain_sessionidx,
-      md5(e.domain_userid || '|' || e.domain_sessionidx) as session_id, --give the session a single unique id
 
       e.event_id, -- for deduplication
       e.event, -- for filtering

--- a/models/events/snowplow_enriched_events.sql
+++ b/models/events/snowplow_enriched_events.sql
@@ -24,6 +24,7 @@ WITH events AS (
 
       e.domain_userid,
       e.domain_sessionidx,
+      md5(e.domain_userid || '|' || e.domain_sessionidx) as session_id, --give the session a single unique id
 
       e.event_id, -- for deduplication
       e.event, -- for filtering


### PR DESCRIPTION
Makes the join from session to events much easier if we pre-calculate the session_id in the events table.