### PR TITLE
more reliably stitch user ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ models:
     snowplow:
         vars:
             'snowplow:timezone': 'America/New_York'
+            'snowplow:page_ping_frequency': 10
             'snowplow:events': "{{ ref('sp_base_events') }}"
             'snowplow:context:web_page': "{{ ref('sp_base_web_page_context') }}"
             'snowplow:context:performance_timing': false

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The [variables](http://dbt.readthedocs.io/en/master/guide/context-variables/#arb
 | variable | information | required |
 |----------|-------------|:--------:|
 |snowplow:timezone|Timezone in which analysis takes place. Used to calculate local times.|No|
+|snowplow:page_ping_frequency|Configured timeout for page pings in tracker (seconds). Default=30|No|
 |snowplow:events|Schema and table containing all snowplow events|Yes|
 |snowplow:context:web_page|Schema and table for web page context|Yes|
 |snowplow:context:performance_timing|Schema and table for perf timing context, or `false` if none is present|Yes|

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,6 +19,7 @@ models:
       #'snowplow:context:performance_timing': TABLE OR {{ REF() }} or FALSE
       #'snowplow:context:useragent': TABLE OR {{ REF() }} or FALSE
       'snowplow:timezone': 'America/New_York'
+      'snowplow:page_ping_frequency': 30
     base:
       materialized: ephemeral
       optional:

--- a/lookml/snowplow_page_views.view.lkml
+++ b/lookml/snowplow_page_views.view.lkml
@@ -136,11 +136,6 @@ view: snowplow_page_views {
     sql: ${TABLE}.horizontal_pixels_scrolled ;;
   }
 
-  dimension: inferred_user_id {
-    type: string
-    sql: ${TABLE}.inferred_user_id ;;
-  }
-
   dimension: ip_address {
     type: string
     sql: ${TABLE}.ip_address ;;

--- a/lookml/snowplow_web_analytics.model.lkml
+++ b/lookml/snowplow_web_analytics.model.lkml
@@ -1,4 +1,4 @@
-connection: "simba_redshift"
+connection: "redshift"
 
 include: "*.view.lkml"         # include all views in this project
 include: "*.dashboard.lookml"  # include all dashboards in this project

--- a/models/page_views/snowplow_page_views.sql
+++ b/models/page_views/snowplow_page_views.sql
@@ -93,6 +93,17 @@ prep as (
         trim(to_char(convert_timezone('UTC', a.os_timezone, b.min_tstamp), 'd')) as page_view_local_day_of_week,
         mod(extract(dow from convert_timezone('UTC', a.os_timezone, b.min_tstamp))::integer - 1 + 7, 7) as page_view_local_day_of_week_index,
 
+        -- engagement
+        b.time_engaged_in_s,
+
+        case
+            when b.time_engaged_in_s between 0 and 9 then '0s to 9s'
+            when b.time_engaged_in_s between 10 and 29 then '10s to 29s'
+            when b.time_engaged_in_s between 30 and 59 then '30s to 59s'
+            when b.time_engaged_in_s > 59 then '60s or more'
+            else null
+        end as time_engaged_in_s_tier,
+
         c.hmax as horizontal_pixels_scrolled,
         c.vmax as vertical_pixels_scrolled,
 
@@ -108,6 +119,8 @@ prep as (
         end as vertical_percentage_scrolled_tier,
 
         case when b.time_engaged_in_s = 0 then true else false end as user_bounced,
+        case when b.time_engaged_in_s >= 30 and c.relative_vmax >= 25 then true else false end as user_engaged,
+
         -- page
         a.page_urlhost || a.page_urlpath as page_url,
 

--- a/models/sessions/snowplow_sessions.sql
+++ b/models/sessions/snowplow_sessions.sql
@@ -1,189 +1,118 @@
 
 {{
     config(
-        materialized='incremental',
+        materialized='table',
         sort='session_start',
-        dist='user_snowplow_domain_id',
-        sql_where='session_start > (select max(session_start) from {{ this }})',
-        unique_key='session_id'
+        dist='user_snowplow_domain_id'
     )
 }}
 
-with web_page_views as (
+with snowplow_sessions as (
 
-    select * from {{ ref('snowplow_page_views') }}
+    select * from {{ ref('snowplow_sessions_tmp') }}
 
 ),
 
-prep AS (
+id_map as (
+
+    select * from {{ ref('snowplow_id_map') }}
+
+),
+
+stitched as (
 
     select
+        user_custom_id,
+        coalesce(id.user_id, user_snowplow_domain_id) as inferred_user_id,
+        user_snowplow_domain_id,
+        user_snowplow_crossdomain_id,
+
+        app_id,
+        bounced_page_views,
+        browser,
+        browser_build_version,
+        browser_engine,
+        browser_language,
+        browser_major_version,
+        browser_minor_version,
+        browser_name,
+        device,
+        device_is_mobile,
+        device_type,
+        first_page_title,
+        first_page_url,
+        first_page_url_fragment,
+        first_page_url_host,
+        first_page_url_path,
+        first_page_url_port,
+        first_page_url_query,
+        first_page_url_scheme,
+        geo_city,
+        geo_country,
+        geo_latitude,
+        geo_longitude,
+        geo_region,
+        geo_region_name,
+        geo_timezone,
+        geo_zipcode,
+        ip_address,
+        ip_domain,
+        ip_isp,
+        ip_net_speed,
+        ip_organization,
+        marketing_campaign,
+        marketing_click_id,
+        marketing_content,
+        marketing_medium,
+        marketing_network,
+        marketing_source,
+        marketing_term,
+        os,
+        os_build_version,
+        os_major_version,
+        os_manufacturer,
+        os_minor_version,
+        os_name,
+        os_timezone,
+        page_views,
+        referer_medium,
+        referer_source,
+        referer_term,
+        referer_url,
+        referer_url_fragment,
+        referer_url_host,
+        referer_url_path,
+        referer_url_port,
+        referer_url_query,
+        referer_url_scheme,
+        session_date,
+        session_end,
+        session_end_local,
+        session_hour,
         session_id,
+        session_index as session_cookie_index,
+        session_local_day_of_week,
+        session_local_day_of_week_index,
+        session_local_hour_of_day,
+        session_local_time,
+        session_local_time_of_day,
+        session_minute,
+        session_month,
+        session_quarter,
+        session_start,
+        session_start_local,
+        session_time,
+        session_week,
+        session_year,
+        user_bounced
 
-        -- time
-        min(page_view_start) as session_start,
-        max(page_view_end) as session_end,
-
-        min(page_view_start_local) as session_start_local,
-        max(page_view_end_local) as session_end_local,
-
-        -- engagement
-        count(*) as page_views,
-
-        sum(case when user_bounced then 1 else 0 end) as bounced_page_views,
-        sum(case when user_engaged then 1 else 0 end) as engaged_page_views,
-
-        sum(time_engaged_in_s) as time_engaged_in_s
-
-    from web_page_views
-
-    group by 1
-    order by 1
-
-),
-
-sessions as (
-
-    select
-        -- user
-        a.user_custom_id,
-        a.inferred_user_id,
-        a.user_snowplow_domain_id,
-        a.user_snowplow_crossdomain_id,
-
-        -- sesssion
-        a.session_id,
-        a.session_index,
-
-        -- session: time
-        b.session_start,
-        b.session_end,
-
-        -- derived dimensions
-        to_char(b.session_start, 'YYYY-MM-DD HH24:MI:SS') as session_time,
-        to_char(b.session_start, 'YYYY-MM-DD HH24:MI') as session_minute,
-        to_char(b.session_start, 'YYYY-MM-DD HH24') as session_hour,
-        to_char(b.session_start, 'YYYY-MM-DD') as session_date,
-        to_char(date_trunc('week', b.session_start), 'YYYY-MM-DD') as session_week,
-        to_char(b.session_start, 'YYYY-MM') as session_month,
-        to_char(date_trunc('quarter', b.session_start), 'YYYY-MM') as session_quarter,
-        date_part('y', b.session_start)::integer as session_year,
-
-        -- session: time in the user's local timezone
-        b.session_start_local,
-        b.session_end_local,
-
-        -- derived dimensions
-        to_char(b.session_start_local, 'YYYY-MM-DD HH24:MI:SS') as session_local_time,
-        to_char(b.session_start_local, 'HH24:MI') as session_local_time_of_day,
-        date_part('hour', b.session_start_local)::integer as session_local_hour_of_day,
-        trim(to_char(b.session_start_local, 'd')) as session_local_day_of_week,
-        mod(extract(dow from b.session_start_local)::integer - 1 + 7, 7) as session_local_day_of_week_index,
-
-        -- engagement
-        b.page_views,
-        b.bounced_page_views,
-        b.engaged_page_views,
-        b.time_engaged_in_s,
-
-        case
-            when b.time_engaged_in_s between 0 and 9 then '0s to 9s'
-            when b.time_engaged_in_s between 10 and 29 then '10s to 29s'
-            when b.time_engaged_in_s between 30 and 59 then '30s to 59s'
-            when b.time_engaged_in_s between 60 and 119 then '60s to 119s'
-            when b.time_engaged_in_s between 120 and 239 then '120s to 239s'
-            when b.time_engaged_in_s > 239 then '240s or more'
-            else null
-        end as time_engaged_in_s_tier,
-
-        case when (b.page_views = 1 and b.bounced_page_views = 1) then true else false end as user_bounced,
-        case when (b.page_views > 2 and b.time_engaged_in_s > 59) or b.engaged_page_views > 0 then true else false end as user_engaged,
-
-        -- first page
-
-        a.page_url as first_page_url,
-
-        a.page_url_scheme as first_page_url_scheme,
-        a.page_url_host as first_page_url_host,
-        a.page_url_port as first_page_url_port,
-        a.page_url_path as first_page_url_path,
-        a.page_url_query as first_page_url_query,
-        a.page_url_fragment as first_page_url_fragment,
-
-        a.page_title as first_page_title,
-
-        -- referer
-        a.referer_url,
-
-        a.referer_url_scheme,
-        a.referer_url_host,
-        a.referer_url_port,
-        a.referer_url_path,
-        a.referer_url_query,
-        a.referer_url_fragment,
-
-        a.referer_medium,
-        a.referer_source,
-        a.referer_term,
-
-        -- marketing
-        a.marketing_medium,
-        a.marketing_source,
-        a.marketing_term,
-        a.marketing_content,
-        a.marketing_campaign,
-        a.marketing_click_id,
-        a.marketing_network,
-
-        -- location
-        a.geo_country,
-        a.geo_region,
-        a.geo_region_name,
-        a.geo_city,
-        a.geo_zipcode,
-        a.geo_latitude,
-        a.geo_longitude,
-        a.geo_timezone, -- can be null
-
-        -- ip
-        a.ip_address,
-        a.ip_isp,
-        a.ip_organization,
-        a.ip_domain,
-        a.ip_net_speed,
-
-        -- application
-        a.app_id,
-
-        -- browser
-        a.browser,
-        a.browser_name,
-        a.browser_major_version,
-        a.browser_minor_version,
-        a.browser_build_version,
-        a.browser_engine,
-
-        a.browser_language,
-
-        -- os
-        a.os,
-        a.os_name,
-        a.os_major_version,
-        a.os_minor_version,
-        a.os_build_version,
-        a.os_manufacturer,
-        a.os_timezone,
-
-        -- device
-        a.device,
-        a.device_type,
-        a.device_is_mobile
-
-    from web_page_views as a
-        inner join prep as b on a.session_id = b.session_id
-
-    where a.page_view_in_session_index = 1
+    from snowplow_sessions as s
+    left outer join id_map as id on s.user_snowplow_domain_id = id.domain_userid
 
 )
 
-select * from sessions
+select
+    *,
+    row_number() over (partition by inferred_user_id order by session_start) as session_index
+
+from stitched

--- a/models/sessions/snowplow_sessions.sql
+++ b/models/sessions/snowplow_sessions.sql
@@ -104,6 +104,8 @@ stitched as (
         session_time,
         session_week,
         session_year,
+        time_engaged_in_s,
+        time_engaged_in_s_tier,
         user_bounced
 
     from snowplow_sessions as s

--- a/models/sessions/snowplow_sessions_tmp.sql
+++ b/models/sessions/snowplow_sessions_tmp.sql
@@ -1,0 +1,172 @@
+
+{{
+    config(
+        materialized='incremental',
+        sort='session_start',
+        dist='user_snowplow_domain_id',
+        sql_where='session_start > (select max(session_start) from {{ this }})',
+        unique_key='session_id'
+    )
+}}
+
+with web_page_views as (
+
+    select * from {{ ref('snowplow_page_views') }}
+
+),
+
+prep AS (
+
+    select
+        session_id,
+
+        -- time
+        min(page_view_start) as session_start,
+        max(page_view_end) as session_end,
+
+        min(page_view_start_local) as session_start_local,
+        max(page_view_end_local) as session_end_local,
+
+        -- engagement
+        count(*) as page_views,
+
+        sum(case when user_bounced then 1 else 0 end) as bounced_page_views
+
+    from web_page_views
+
+    group by 1
+    order by 1
+
+),
+
+sessions as (
+
+    select
+        -- user
+        a.user_custom_id,
+        a.user_snowplow_domain_id,
+        a.user_snowplow_crossdomain_id,
+
+        -- sesssion
+        a.session_id,
+        a.session_index,
+
+        -- session: time
+        b.session_start,
+        b.session_end,
+
+        -- derived dimensions
+        to_char(b.session_start, 'YYYY-MM-DD HH24:MI:SS') as session_time,
+        to_char(b.session_start, 'YYYY-MM-DD HH24:MI') as session_minute,
+        to_char(b.session_start, 'YYYY-MM-DD HH24') as session_hour,
+        to_char(b.session_start, 'YYYY-MM-DD') as session_date,
+        to_char(date_trunc('week', b.session_start), 'YYYY-MM-DD') as session_week,
+        to_char(b.session_start, 'YYYY-MM') as session_month,
+        to_char(date_trunc('quarter', b.session_start), 'YYYY-MM') as session_quarter,
+        date_part('y', b.session_start)::integer as session_year,
+
+        -- session: time in the user's local timezone
+        b.session_start_local,
+        b.session_end_local,
+
+        -- derived dimensions
+        to_char(b.session_start_local, 'YYYY-MM-DD HH24:MI:SS') as session_local_time,
+        to_char(b.session_start_local, 'HH24:MI') as session_local_time_of_day,
+        date_part('hour', b.session_start_local)::integer as session_local_hour_of_day,
+        trim(to_char(b.session_start_local, 'd')) as session_local_day_of_week,
+        mod(extract(dow from b.session_start_local)::integer - 1 + 7, 7) as session_local_day_of_week_index,
+
+        -- engagement
+        b.page_views,
+        b.bounced_page_views,
+
+        case when (b.page_views = 1 and b.bounced_page_views = 1) then true else false end as user_bounced,
+
+        -- first page
+
+        a.page_url as first_page_url,
+
+        a.page_url_scheme as first_page_url_scheme,
+        a.page_url_host as first_page_url_host,
+        a.page_url_port as first_page_url_port,
+        a.page_url_path as first_page_url_path,
+        a.page_url_query as first_page_url_query,
+        a.page_url_fragment as first_page_url_fragment,
+
+        a.page_title as first_page_title,
+
+        -- referer
+        a.referer_url,
+
+        a.referer_url_scheme,
+        a.referer_url_host,
+        a.referer_url_port,
+        a.referer_url_path,
+        a.referer_url_query,
+        a.referer_url_fragment,
+
+        a.referer_medium,
+        a.referer_source,
+        a.referer_term,
+
+        -- marketing
+        a.marketing_medium,
+        a.marketing_source,
+        a.marketing_term,
+        a.marketing_content,
+        a.marketing_campaign,
+        a.marketing_click_id,
+        a.marketing_network,
+
+        -- location
+        a.geo_country,
+        a.geo_region,
+        a.geo_region_name,
+        a.geo_city,
+        a.geo_zipcode,
+        a.geo_latitude,
+        a.geo_longitude,
+        a.geo_timezone, -- can be null
+
+        -- ip
+        a.ip_address,
+        a.ip_isp,
+        a.ip_organization,
+        a.ip_domain,
+        a.ip_net_speed,
+
+        -- application
+        a.app_id,
+
+        -- browser
+        a.browser,
+        a.browser_name,
+        a.browser_major_version,
+        a.browser_minor_version,
+        a.browser_build_version,
+        a.browser_engine,
+
+        a.browser_language,
+
+        -- os
+        a.os,
+        a.os_name,
+        a.os_major_version,
+        a.os_minor_version,
+        a.os_build_version,
+        a.os_manufacturer,
+        a.os_timezone,
+
+        -- device
+        a.device,
+        a.device_type,
+        a.device_is_mobile
+
+    from web_page_views as a
+        inner join prep as b on a.session_id = b.session_id
+
+    where a.page_view_in_session_index = 1
+
+)
+
+select * from sessions

--- a/models/sessions/snowplow_sessions_tmp.sql
+++ b/models/sessions/snowplow_sessions_tmp.sql
@@ -30,7 +30,10 @@ prep AS (
         -- engagement
         count(*) as page_views,
 
-        sum(case when user_bounced then 1 else 0 end) as bounced_page_views
+        sum(case when user_bounced then 1 else 0 end) as bounced_page_views,
+        sum(case when user_engaged then 1 else 0 end) as engaged_page_views,
+
+        sum(time_engaged_in_s) as time_engaged_in_s
 
     from web_page_views
 
@@ -80,7 +83,21 @@ sessions as (
         b.page_views,
         b.bounced_page_views,
 
+        b.engaged_page_views,
+        b.time_engaged_in_s,
+
+        case
+            when b.time_engaged_in_s between 0 and 9 then '0s to 9s'
+            when b.time_engaged_in_s between 10 and 29 then '10s to 29s'
+            when b.time_engaged_in_s between 30 and 59 then '30s to 59s'
+            when b.time_engaged_in_s between 60 and 119 then '60s to 119s'
+            when b.time_engaged_in_s between 120 and 239 then '120s to 239s'
+            when b.time_engaged_in_s > 239 then '240s or more'
+            else null
+        end as time_engaged_in_s_tier,
+
         case when (b.page_views = 1 and b.bounced_page_views = 1) then true else false end as user_bounced,
+        case when (b.page_views > 2 and b.time_engaged_in_s > 59) or b.engaged_page_views > 0 then true else false end as user_engaged,
 
         -- first page
 

--- a/models/users/snowplow_users.sql
+++ b/models/users/snowplow_users.sql
@@ -25,7 +25,8 @@ prep as (
         min(session_start_local) as first_session_start_local,
         max(session_end) as last_session_end,
         sum(page_views) as page_views,
-        count(*) as sessions
+        count(*) as sessions,
+        sum(time_engaged_in_s) as time_engaged_in_s
 
     from sessions
 
@@ -71,6 +72,7 @@ users as (
         -- engagement
         b.page_views,
         b.sessions,
+        b.time_engaged_in_s,
 
         -- first page
         a.first_page_url,

--- a/models/users/snowplow_users.sql
+++ b/models/users/snowplow_users.sql
@@ -25,8 +25,7 @@ prep as (
         min(session_start_local) as first_session_start_local,
         max(session_end) as last_session_end,
         sum(page_views) as page_views,
-        count(*) as sessions,
-        sum(time_engaged_in_s) as time_engaged_in_s
+        count(*) as sessions
 
     from sessions
 
@@ -72,7 +71,6 @@ users as (
         -- engagement
         b.page_views,
         b.sessions,
-        b.time_engaged_in_s,
 
         -- first page
         a.first_page_url,


### PR DESCRIPTION
previously, we did identity stitching in the `page_views` model. This was unreliable, as previously committed records were not updated with new `inferred_user_id`s due to the incremental nature of these models. Now, stitching occurs at the session level, and is applied retroactively to all sessions.

TODO:
- [x] update Lookml