### PR TITLE
swap vars, change field names

### DIFF
--- a/models/page_views/optional/snowplow_web_timing_context.sql
+++ b/models/page_views/optional/snowplow_web_timing_context.sql
@@ -42,7 +42,7 @@ prep as (
         pt.load_event_end
 
     from performance_timing_context as pt
-        inner join web_page_context as wp on pt.root_id = wp.root_id
+        inner join web_page_context as wp using (event_id)
 
     -- all values should be set and some have to be greater than 0 (not the case in about 1% of events)
     where pt.navigation_start is not null and pt.navigation_start > 0

--- a/models/page_views/snowplow_page_views.sql
+++ b/models/page_views/snowplow_page_views.sql
@@ -79,13 +79,13 @@ web_events_scroll_depth as (
 
 {% if use_perf_timing != false %}
 
-    web_ua_parser_context as ( select * from {{ ref('snowplow_web_ua_parser_context') }} ),
+    web_timing_context as ( select * from {{ ref('snowplow_web_timing_context') }} ),
 
 {% endif %}
 
 {% if use_useragents != false %}
 
-    web_timing_context as ( select * from {{ ref('snowplow_web_timing_context') }} ),
+    web_ua_parser_context as ( select * from {{ ref('snowplow_web_ua_parser_context') }} ),
 
 {% endif %}
 

--- a/models/page_views/snowplow_page_views.sql
+++ b/models/page_views/snowplow_page_views.sql
@@ -302,13 +302,13 @@ prep as (
 
         {% if use_useragents %}
 
-            inner join web_ua_parser_context as d on a.page_view_id = d.page_view_id
+            left outer join web_ua_parser_context as d on a.page_view_id = d.page_view_id
 
         {% endif %}
 
         {% if use_perf_timing %}
 
-            inner join web_timing_context as e on a.page_view_id = e.page_view_id
+            left outer join web_timing_context as e on a.page_view_id = e.page_view_id
 
         {% endif %}
 

--- a/models/page_views/snowplow_web_events_scroll_depth.sql
+++ b/models/page_views/snowplow_web_events_scroll_depth.sql
@@ -112,6 +112,7 @@ relevant_existing as (
         relative_vmin,
         relative_vmax
     from {{ this }}
+    where page_view_id in (select page_view_id from relative)
 ),
 
 unioned as (


### PR DESCRIPTION
Additionally, this fixes a long-standing bug with the `snowplow_web_events_scroll_depth` model which caused this table to consume an inordinate amount of disk space.