### PR TITLE
Add event_id to web events

### DIFF
--- a/models/page_views/snowplow_web_events.sql
+++ b/models/page_views/snowplow_web_events.sql
@@ -41,6 +41,8 @@ prep as (
 
     select
 
+        ev.event_id,
+
         ev.user_id,
         ev.domain_userid,
         ev.network_userid,


### PR DESCRIPTION
Add `event_id` to `snowplow_web_events` model. This is useful for joining clean event data to custom contexts.