### PR TITLE
fix for bad filters on useragent and br_family

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
-            pip install dbt==0.10.2
+            pip install dbt
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml
 

--- a/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
+++ b/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
@@ -170,8 +170,11 @@ page_views as (
 
   from events
   where event = 'page_view'
-    and br_family != 'Robot/Spider'
-    AND NOT regexp_contains(useragent, '^.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt).*$')
+    and (br_family != 'Robot/Spider' or br_family is null)
+    and (
+        not regexp_contains(useragent, '^.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt).*$')
+        or useragent is null
+    )
     and domain_userid is not null
     and domain_sessionidx > 0
 

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -304,8 +304,11 @@ prep as (
 
         {% endif %}
 
-    where a.br_family != 'Robot/Spider'
-      and a.useragent not {{ snowplow.similar_to('%(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt)%') }}
+    where (a.br_family != 'Robot/Spider' or a.br_family is null)
+      and (
+        a.useragent not {{ snowplow.similar_to('%(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt)%') }}
+        or a.useragent is null
+      )
       and a.domain_userid is not null
       and a.domain_sessionidx > 0
 


### PR DESCRIPTION
Handle the case where these values are `null`

closes https://github.com/fishtown-analytics/snowplow/issues/34