### PR TITLE
Addition of "replace" to os_timezone field to fix timezone bug.

### DIFF
--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -125,8 +125,8 @@ prep as (
         CONVERT_TIMEZONE('UTC', '{{ timezone }}', b.max_tstamp) as page_view_end,
 
         -- page view: time in the user's local timezone
-        convert_timezone('UTC', coalesce(replace(a.os_timezone, '%2F', '/'), '{{ timezone }}'), b.min_tstamp) as page_view_start_local,
-        convert_timezone('UTC', coalesce(replace(a.os_timezone, '%2F', '/'), '{{ timezone }}'), b.max_tstamp) as page_view_end_local,
+        convert_timezone('UTC', coalesce(a.os_timezone, '{{ timezone }}'), b.min_tstamp) as page_view_start_local,
+        convert_timezone('UTC', coalesce(a.os_timezone, '{{ timezone }}'), b.max_tstamp) as page_view_end_local,
 
         -- engagement
         b.time_engaged_in_s,

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -125,8 +125,8 @@ prep as (
         CONVERT_TIMEZONE('UTC', '{{ timezone }}', b.max_tstamp) as page_view_end,
 
         -- page view: time in the user's local timezone
-        convert_timezone('UTC', coalesce(a.os_timezone, '{{ timezone }}'), b.min_tstamp) as page_view_start_local,
-        convert_timezone('UTC', coalesce(a.os_timezone, '{{ timezone }}'), b.max_tstamp) as page_view_end_local,
+        convert_timezone('UTC', coalesce(replace(a.os_timezone, '%2F', '/'), '{{ timezone }}'), b.min_tstamp) as page_view_start_local,
+        convert_timezone('UTC', coalesce(replace(a.os_timezone, '%2F', '/'), '{{ timezone }}'), b.max_tstamp) as page_view_end_local,
 
         -- engagement
         b.time_engaged_in_s,

--- a/macros/adapters/default/page_views/snowplow_web_events.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events.sql
@@ -122,7 +122,7 @@ prep as (
         ev.os_name,
         ev.os_family,
         ev.os_manufacturer,
-        ev.os_timezone,
+        replace(ev.os_timezone, '%2F', '/')
 
         ev.name_tracker, -- included to filter on
         ev.dvce_created_tstamp -- included to sort on

--- a/macros/adapters/default/page_views/snowplow_web_events.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events.sql
@@ -122,7 +122,7 @@ prep as (
         ev.os_name,
         ev.os_family,
         ev.os_manufacturer,
-        replace(ev.os_timezone, '%2F', '/')
+        replace(ev.os_timezone, '%2F', '/') as os_timezone,
 
         ev.name_tracker, -- included to filter on
         ev.dvce_created_tstamp -- included to sort on


### PR DESCRIPTION
Windows XP + IE 8 reports a bad (url encoded) timezone value
through the Snowplow JS tracker. Upon providing the SQL method
`CONVERT_TIMEZONE` with an invalid value, the execution will
raise an exception. This change replaces the url encoded slash,
which separates the continent from the zone, with the proper
slash.

DBT error, against Snowflake:
```
Database Error in model snowplow_page_views (models/page_views/snowplow_page_views.sql)
100094 (22000): 43ad1b72-dd77-4964-9bfb-a3f8743f6daf: Unknown timezone: 'Europe%2FLondon'
compiled SQL at target/compiled/snowplow/page_views/snowplow_page_views.sql
```
Replace appears to be supported by both BigQuery and Snowflake. 
https://cloud.google.com/bigquery/docs/reference/standard-sql/functions-and-operators#replace
https://docs.snowflake.net/manuals/sql-reference/functions/replace.html