### PR TITLE
added user_bounced to sessions

### DIFF
--- a/macros/adapters/bigquery/sessions/snowplow_sessions_tmp.sql
+++ b/macros/adapters/bigquery/sessions/snowplow_sessions_tmp.sql
@@ -96,6 +96,7 @@ sessions as (
 
     struct(
         engagement.engaged_page_views,
+        engagement.user_bounced,
         engagement.time_engaged_in_s,
         case
             when engagement.time_engaged_in_s between 0 and 9 then '0s to 9s'


### PR DESCRIPTION
@drewbanin this one is actually a modeling change, not lookml... The BQ models were missing the `user_bounced` field.