### PR TITLE
dedupe session ids when orphaned page views occur

### DIFF
--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -80,6 +80,7 @@ web_events_fixed as (
 
         -- likewise, replace the urlquery with parent's if internal & undefined in this pv
         coalesce(w.page_urlquery, i.parent_urlquery) as page_url_query,
+        coalesce(i.is_internal, false::boolean) as is_internal,
 
         w.*
 
@@ -299,8 +300,10 @@ prep as (
         -- device
         a.br_renderengine as browser_engine,
         a.dvce_type as device_type,
-        a.dvce_ismobile as device_is_mobile
+        a.dvce_ismobile as device_is_mobile,
 
+        -- meta
+        a.is_internal as is_internal
 
     from web_events_fixed as a
         inner join web_events_time as b on a.page_view_id = b.page_view_id

--- a/macros/adapters/default/page_views/snowplow_web_events_internal_fixed.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events_internal_fixed.sql
@@ -47,7 +47,8 @@ mapping as (
         {{ snowplow.get_utm_parameter('parent_urlquery', 'utm_medium') }} as utm_medium,
         {{ snowplow.get_utm_parameter('parent_urlquery', 'utm_campaign') }} as utm_campaign,
         {{ snowplow.get_utm_parameter('parent_urlquery', 'utm_content') }} as utm_content,
-        {{ snowplow.get_utm_parameter('parent_urlquery', 'utm_term') }} as utm_term
+        {{ snowplow.get_utm_parameter('parent_urlquery', 'utm_term') }} as utm_term,
+        true::boolean as is_internal
 
     from sessions
     where refr_medium = 'internal'

--- a/macros/adapters/default/sessions/snowplow_sessions_tmp.sql
+++ b/macros/adapters/default/sessions/snowplow_sessions_tmp.sql
@@ -200,7 +200,7 @@ sessions as (
         inner join prep as b on a.session_id = b.session_id
 
     where a.page_view_in_session_index = 1
-
+      and coalesce(a.is_internal, false) = false
 
 )
 


### PR DESCRIPTION
- Fix for duplicated sessions when late arriving facts are received