### PR TITLE
remove timestamp cast to collector_tstamp in page_views

### DIFF
--- a/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
+++ b/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
@@ -205,7 +205,7 @@ page_pings as (
     array_agg(struct(
       event_id,
       event,
-      collector_tstamp,
+      cast(collector_tstamp as timestamp),
       pp_xoffset_min,
       pp_xoffset_max,
       pp_yoffset_min,

--- a/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
+++ b/macros/adapters/bigquery/pageviews/snowplow_page_views.sql
@@ -183,8 +183,8 @@ page_pings as (
 
   select
     page_view_id,
-    min(timestamp(collector_tstamp)) as page_view_start,
-    max(timestamp(collector_tstamp)) as page_view_end,
+    min(collector_tstamp) as page_view_start,
+    max(collector_tstamp) as page_view_end,
 
     struct(
         max(doc_width) as doc_width,
@@ -205,7 +205,7 @@ page_pings as (
     array_agg(struct(
       event_id,
       event,
-      timestamp(collector_tstamp) as collector_tstamp,
+      collector_tstamp,
       pp_xoffset_min,
       pp_xoffset_max,
       pp_yoffset_min,

--- a/macros/adapters/bigquery/sessions/snowplow_sessions_tmp.sql
+++ b/macros/adapters/bigquery/sessions/snowplow_sessions_tmp.sql
@@ -40,7 +40,7 @@ sessions_agg as (
 
     select
         pv.session_id,
-        array_agg(pv order by pv.page_view_start) as all_pageviews
+        array_agg(pv order by pv.page_view_in_session_index) as all_pageviews
 
     from relevant_page_views as pv
     group by 1

--- a/macros/adapters/bigquery/sessions/snowplow_sessions_tmp.sql
+++ b/macros/adapters/bigquery/sessions/snowplow_sessions_tmp.sql
@@ -40,7 +40,7 @@ sessions_agg as (
 
     select
         pv.session_id,
-        array_agg(pv order by pv.page_view_in_session_index) as all_pageviews
+        array_agg(pv order by pv.page_view_start) as all_pageviews
 
     from relevant_page_views as pv
     group by 1


### PR DESCRIPTION
* Removed `timestamp(colllector_tstamp)` casting because BQ doesn't allow casting fields to the same datatype
* Changed the session roll-up in `snowplow_page_views` to be based on `page_view_in_session_index` -- this is because the order of the page views is reliant on `dvce_created_timestamp` which then creates the `page_view_in_session_index`. However, this package is currently using `page_view_start`, which is not the consistent timestamp