### PR TITLE
Rm internal session mapping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install -U pip
             pip install dbt
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -56,39 +56,6 @@ web_events as (
 
 ),
 
-internal_session_mapping as (
-
-    select * from {{ ref('snowplow_web_events_internal_fixed') }}
-
-),
-
--- coalesce "stagnant" sessions which would result in internal referers
-web_events_fixed as (
-
-    select
-        -- use parent if available, otherwise use session id on web event
-        coalesce(i.parent_sessionid, w.domain_sessionid) as session_id,
-
-        -- use web params if they're there, otherwise fall back to parent
-        -- the i.utm_* fields are only defined if the current web event is internal,
-        -- so this doesn't play with "correct" sessions -- only the orphaned ones
-        coalesce(w.mkt_medium, i.utm_medium) as marketing_medium,
-        coalesce(w.mkt_source, i.utm_source) as marketing_source,
-        coalesce(w.mkt_campaign, i.utm_campaign) as marketing_campaign,
-        coalesce(w.mkt_term, i.utm_term) as marketing_term,
-        coalesce(w.mkt_content, i.utm_content) as marketing_content,
-
-        -- likewise, replace the urlquery with parent's if internal & undefined in this pv
-        coalesce(w.page_urlquery, i.parent_urlquery) as page_url_query,
-        coalesce(i.is_internal, false::boolean) as is_internal,
-
-        w.*
-
-    from web_events as w
-    left outer join internal_session_mapping as i on i.domain_sessionid = w.domain_sessionid
-
-),
-
 web_events_time as (
 
     select * from {{ ref('snowplow_web_events_time') }}
@@ -125,15 +92,15 @@ prep as (
         b.max_tstamp,
 
         -- sesssion
-        a.session_id,
+        a.domain_sessionid as session_id,
         a.domain_sessionidx as session_index,
 
         -- page view
         a.page_view_id,
 
         row_number() over (partition by a.domain_userid order by a.dvce_created_tstamp) as page_view_index,
-        row_number() over (partition by a.session_id order by a.dvce_created_tstamp) as page_view_in_session_index,
-        count(*) over (partition by session_id) as max_session_page_view_index,
+        row_number() over (partition by a.domain_sessionid order by a.dvce_created_tstamp) as page_view_in_session_index,
+        count(*) over (partition by domain_sessionid) as max_session_page_view_index,
 
         -- page view: time
         CONVERT_TIMEZONE('UTC', '{{ timezone }}', b.min_tstamp) as page_view_start,
@@ -177,7 +144,7 @@ prep as (
         a.page_urlhost as page_url_host,
         a.page_urlport as page_url_port,
         a.page_urlpath as page_url_path,
-        a.page_url_query,
+        a.page_urlquery as page_url_query,
         a.page_urlfragment as page_url_fragment,
 
         a.page_title,
@@ -205,11 +172,11 @@ prep as (
 
         -- marketing
         -- these are "fixed" in the CTE above (if needed)
-        a.marketing_medium,
-        a.marketing_source,
-        a.marketing_term,
-        a.marketing_content,
-        a.marketing_campaign,
+        a.mkt_medium as marketing_medium,
+        a.mkt_source as marketing_source,
+        a.mkt_term as marketing_term,
+        a.mkt_content as marketing_content,
+        a.mkt_campaign as marketing_campaign,
         -- these come straight from the event
         a.mkt_clickid as marketing_click_id,
         a.mkt_network as marketing_network,
@@ -300,16 +267,13 @@ prep as (
         -- device
         a.br_renderengine as browser_engine,
         a.dvce_type as device_type,
-        a.dvce_ismobile as device_is_mobile,
-
-        -- meta
-        a.is_internal as is_internal
+        a.dvce_ismobile as device_is_mobile
         
         {%- for column in var('snowplow:pass_through_columns') %}
         , a.{{column}}
-        {% endfor -%}
+        {% endfor %}
 
-    from web_events_fixed as a
+    from web_events as a
         inner join web_events_time as b on a.page_view_id = b.page_view_id
         inner join web_events_scroll_depth as c on a.page_view_id = c.page_view_id
 

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -171,7 +171,6 @@ prep as (
         a.refr_term as referer_term,
 
         -- marketing
-        -- these are "fixed" in the CTE above (if needed)
         a.mkt_medium as marketing_medium,
         a.mkt_source as marketing_source,
         a.mkt_term as marketing_term,

--- a/macros/adapters/default/page_views/snowplow_web_events.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events.sql
@@ -128,7 +128,7 @@ prep as (
         
         {%- for column in var('snowplow:pass_through_columns') %}
         , ev.{{column}}
-        {% endfor -%}
+        {% endfor %}
 
     from events as ev
         inner join web_page_context as wp  on ev.event_id = wp.root_id

--- a/macros/adapters/default/sessions/snowplow_sessions.sql
+++ b/macros/adapters/default/sessions/snowplow_sessions.sql
@@ -107,7 +107,7 @@ stitched as (
         {%- for column in var('snowplow:pass_through_columns') %}
         , first_{{column}}
         , last_{{column}}
-        {% endfor -%}
+        {% endfor %}
 
     from snowplow_sessions as s
     left outer join id_map as id on s.user_snowplow_domain_id = id.domain_userid

--- a/macros/adapters/default/sessions/snowplow_sessions_tmp.sql
+++ b/macros/adapters/default/sessions/snowplow_sessions_tmp.sql
@@ -66,12 +66,12 @@ prep AS (
         sum(time_engaged_in_s) as time_engaged_in_s,
 
         max(case when last_page_view_in_session = 1 then page_url else null end)
-            as exit_page_url,
+            as exit_page_url
         
         {%- for column in var('snowplow:pass_through_columns') %}
-        max(case when last_page_view_in_session = 1 then {{column}} else null end)
+        , max(case when last_page_view_in_session = 1 then {{column}} else null end)
             as {{column}}
-        {% endfor -%}
+        {% endfor %}
 
     from web_page_views
 
@@ -204,13 +204,12 @@ sessions as (
         {%- for column in var('snowplow:pass_through_columns') %}
         , a.{{column}} as first_{{column}}
         , b.{{column}} as last_{{column}}
-        {% endfor -%}
+        {% endfor %}
 
     from web_page_views as a
         inner join prep as b on a.session_id = b.session_id
 
     where a.page_view_in_session_index = 1
-      and coalesce(a.is_internal, false) = false
 
 )
 

--- a/models/page_views/snowplow_web_events_internal_fixed.sql
+++ b/models/page_views/snowplow_web_events_internal_fixed.sql
@@ -1,2 +1,0 @@
-
-{{ snowplow_web_events_internal_fixed() }}


### PR DESCRIPTION
### Background

[Snowplow marks page views](https://discourse.snowplowanalytics.com/t/what-are-all-possible-values-of-the-refr-medium-field/212) with `refr_medium = 'internal'`
> when the page URL and referrer URL have the same host, or when the referring domain is configured as internal

At present, the Snowplow package attempts to attach internally referred sessions to their parent sessions. The benefits:

* Map original (parent) UTMs and referer information for internally referred sessions that contain conversions

This has unintended consequences:

* Not every `session_id` from valid events shows up in `snowplow_sessions`, which makes rollup of additional measures or custom contextual information much more difficult—need to join to `snowplow_web_events_internal_fixed` model and map parents in multiple places.
* There are some page views with `refr_medium = 'internal'` that are missing parent sessions, resulting in page views that do not have requisite sessions in `snowplow_sessions`. That is, we _lose_ some conversions because they occur in orphaned sessions!

The benefits are not worth the added complexity / risk of data loss. Stitching UTMs/referers for internal sessions should be a downstream problem for marketers, exposed in a transparent way, rather than a core feature of our sessionization logic.

### Release cadence

We've merged a couple of small feature / fixup PRs—#51 and #53, #57 open but seems ready—since the last release. Since this PR changes functionality significantly, I wonder if we should merge #57, do a minor release of the package (0.7.3), merge this in, and then a major release to follow (0.8.0).

The _next_ major release after that (0.9.0) would be #52 (native support for embedded `page_view_id` in Snowflake/BQ) + redoing cross-adapter support as model configs rather than macros.