### PR TITLE
Add browser columns and change Unioned CTE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip setuptools
             pip install dbt
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml

--- a/README.md
+++ b/README.md
@@ -14,16 +14,10 @@ several intermediate models used to create these two models.
 
 ![snowplow graph](/etc/snowplow_graph.png)
 
-### Installation ###
-
-- Include the following in your `packages.yml` file:
-```YAML
-packages:
-  - package: fishtown-analytics/snowplow
-    version: 0.7.3
-```
-
-- Run `dbt deps` to install the package.
+## Installation Instructions
+Check [dbt Hub](https://hub.getdbt.com/fishtown-analytics/snowplow/latest/) for
+the latest installation instructions, or [read the docs](https://docs.getdbt.com/docs/package-management)
+for more information on installing packages.
 
 ## Configuration ###
 

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -248,9 +248,9 @@ prep as (
             d.device_family as device,
         {% else %}
             null::text as browser,
-            null::text as browser_name,
-            null::text as browser_major_version,
-            null::text as browser_minor_version,
+            a.br_family as browser_name,
+            a.br_name as browser_major_version,
+            a.br_version as browser_minor_version,
             null::text as browser_build_version,
             a.os_family as os,
             a.os_name as os_name,

--- a/macros/adapters/default/page_views/snowplow_web_events_scroll_depth.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events_scroll_depth.sql
@@ -120,7 +120,7 @@ relevant_existing as (
     where page_view_id in (select page_view_id from relative)
 ),
 
-unioned as (
+unioned_cte as (
 
     select
         page_view_id,
@@ -179,7 +179,7 @@ merged as (
         max(relative_vmin) as relative_vmin,
         max(relative_vmax) as relative_vmax
 
-    from unioned
+    from unioned_cte
     group by 1
 
 

--- a/macros/adapters/default/page_views/snowplow_web_events_time.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events_time.sql
@@ -81,7 +81,7 @@ relevant_existing as (
 
 ),
 
-unioned as (
+unioned_cte as (
 
     select
         page_view_id,
@@ -115,7 +115,7 @@ merged as (
         sum(pp_count) as pp_count,
         sum(time_engaged_in_s) as time_engaged_in_s
 
-    from unioned
+    from unioned_cte
     group by 1
 
 


### PR DESCRIPTION
This PR adds 3 columns for browser info to the page_views model. It also renames the `unioned` CTE to avoid a Snowflake-specific bug where the name of the CTE was creating a Recursive CTE error.