### PR TITLE
Update integration tests to use latest pip and setuptools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           command: |
             python3 -m venv venv
             . venv/bin/activate
+            pip install --upgrade pip setuptools
             pip install dbt
             mkdir -p ~/.dbt
             cp integration_tests/ci/sample.profiles.yml ~/.dbt/profiles.yml


### PR DESCRIPTION
Following the pattern in dbt utils ([here](https://github.com/fishtown-analytics/dbt-utils/pull/141/files))