### PR TITLE
Speed up working of snowplow_page_views model

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The [variables](https://docs.getdbt.com/docs/using-variables) needed to configur
 |snowplow:context:performance_timing|Schema and table for perf timing context, or `false` if none is present|Yes|
 |snowplow:context:useragent|Schema and table for useragent context, or `false` if none is available|Yes|
 |snowplow:pass_through_columns|Additional columns for inclusion in final models|No|
+|snowplow:page_view_lookback_days|Amount of days to rescan to merge page_views in the same session|Yes|
 
 An example `dbt_project.yml` configuration:
 
@@ -50,6 +51,7 @@ models:
             'snowplow:context:performance_timing': false
             'snowplow:context:useragent': false
             'snowplow:pass_through_columns': []
+            'snowplow:page_view_lookback_days': 1
     base:
       optional:
         enabled: false

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,3 +30,4 @@ models:
       'snowplow:page_ping_frequency': 30
       'snowplow:app_ids': []
       'snowplow:pass_through_columns': []
+      'snowplow:page_view_lookback_days': 1

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -24,6 +24,8 @@
 {% set use_perf_timing = (var('snowplow:context:performance_timing') != false) %}
 {% set use_useragents = (var('snowplow:context:useragent') != false) %}
 
+{% set lookback_days = var('snowplow:page_view_lookback_days', '1') %}
+
 -- we are using 1-days window allowing us cover most of sessions
 -- but model become much faster comparing to selecting all events
 with all_events as (
@@ -31,7 +33,7 @@ with all_events as (
     select * from {{ ref('snowplow_web_events') }}
     {% if is_incremental() %}
     where collector_tstamp > (
-        DATEADD('day', -1, (select coalesce(max(max_tstamp), '0001-01-01') from {{ this }}))
+        DATEADD('day', -1 * '{{ lookback_days }}', (select coalesce(max(max_tstamp), '0001-01-01') from {{ this }}))
         )
     {% endif %}
 ),

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -333,7 +333,7 @@ prep as (
         {% endif %}
 
     where (a.br_family != 'Robot/Spider' or a.br_family is null)
-      and (
+      and not (
     (useragent like '%bot%'
     or useragent like '%crawl%'
     or useragent like '%slurp%'

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -24,9 +24,16 @@
 {% set use_perf_timing = (var('snowplow:context:performance_timing') != false) %}
 {% set use_useragents = (var('snowplow:context:useragent') != false) %}
 
+-- we are using 1-days window allowing us cover most of sessions
+-- but model become much faster comparing to selecting all events
 with all_events as (
 
     select * from {{ ref('snowplow_web_events') }}
+    {% if is_incremental() %}
+    where collector_tstamp > (
+        DATEADD('day', -1, (select coalesce(max(max_tstamp), '0001-01-01') from {{ this }}))
+        )
+    {% endif %}
 ),
 
 filtered_events as (
@@ -42,8 +49,6 @@ filtered_events as (
 
 -- we need to grab all events for any session that has appeared
 -- in order to correctly process the session index below
--- we are using 30-days window allowing us cover 99% of sessions
--- but model become much faster
 relevant_sessions as (
 
     select distinct domain_sessionid
@@ -55,11 +60,6 @@ web_events as (
     select all_events.*
     from all_events
     join relevant_sessions using (domain_sessionid)
-    {% if is_incremental() %}
-    where collector_tstamp > (
-        DATEADD('day', -30, (select coalesce(max(max_tstamp), '0001-01-01') from {{ this }}))
-    )
-    {% endif %}
 
 ),
 
@@ -333,7 +333,40 @@ prep as (
         {% endif %}
 
     where (a.br_family != 'Robot/Spider' or a.br_family is null)
-      and (a.useragent not {{ snowplow.similar_to('%(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt)%') }}
+      and (
+    (useragent like '%bot%'
+    or useragent like '%crawl%'
+    or useragent like '%slurp%'
+    or useragent like '%spider%'
+    or useragent like '%archiv%'
+    or useragent like '%spinn%'
+    or useragent like '%sniff%'
+    or useragent like '%seo%'
+    or useragent like '%audit%'
+    or useragent like '%survey%'
+    or useragent like '%pingdom%'
+    or useragent like '%worm%'
+    or useragent like '%capture%'
+    or useragent like '%browsershots%'
+    or useragent like '%screenshots%'
+    or useragent like '%analyz%'
+    or useragent like '%index%'
+    or useragent like '%thumb%'
+    or useragent like '%check%'
+    or useragent like '%facebook%'
+    or useragent like '%PingdomBot%'
+    or useragent like '%PhantomJS%'
+    or useragent like '%YorexBot%'
+    or useragent like '%Twitterbot%'
+    or useragent like '%a_archiver%'
+    or useragent like '%facebookexternalhit%'
+    or useragent like '%Bingbot%'
+    or useragent like '%BingPreview%'
+    or useragent like '%Googlebot%'
+    or useragent like '%Baiduspider%'
+    or useragent like '%360Spider%'
+    or useragent like '%360User-agent%'
+    or useragent like '%semalt%')
         or a.useragent is null)
       and coalesce(a.br_type, 'unknown') not in ('Bot/Crawler', 'Robot')
       and a.domain_userid is not null

--- a/macros/adapters/default/page_views/snowplow_page_views.sql
+++ b/macros/adapters/default/page_views/snowplow_page_views.sql
@@ -24,8 +24,6 @@
 {% set use_perf_timing = (var('snowplow:context:performance_timing') != false) %}
 {% set use_useragents = (var('snowplow:context:useragent') != false) %}
 
-{% set lookback_days = var('snowplow:page_view_lookback_days', '1') %}
-
 -- we are using 1-days window allowing us cover most of sessions
 -- but model become much faster comparing to selecting all events
 with all_events as (
@@ -33,7 +31,7 @@ with all_events as (
     select * from {{ ref('snowplow_web_events') }}
     {% if is_incremental() %}
     where collector_tstamp > (
-        DATEADD('day', -1 * '{{ lookback_days }}', (select coalesce(max(max_tstamp), '0001-01-01') from {{ this }}))
+        DATEADD('day', -1 * {{var('snowplow:page_view_lookback_days')}}, (select coalesce(max(max_tstamp), '0001-01-01') from {{ this }}))
         )
     {% endif %}
 ),

--- a/macros/adapters/default/page_views/snowplow_web_events.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events.sql
@@ -15,7 +15,7 @@
 {{
     config(
         materialized='incremental',
-        sort=['collector_tstamp', 'page_view_id', 'domain_sessionid', 'domain_userid', 'dvce_created_tstamp'],
+        sort='page_view_id',
         dist='page_view_id',
         unique_key='page_view_id'
     )

--- a/macros/adapters/default/page_views/snowplow_web_events.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events.sql
@@ -15,7 +15,7 @@
 {{
     config(
         materialized='incremental',
-        sort=['page_view_id', 'collector_tstamp', 'domain_sessionid', 'domain_userid', 'dvce_created_tstamp'],
+        sort=['collector_tstamp', 'page_view_id', 'domain_sessionid', 'domain_userid', 'dvce_created_tstamp'],
         dist='page_view_id',
         unique_key='page_view_id'
     )

--- a/macros/adapters/default/page_views/snowplow_web_events.sql
+++ b/macros/adapters/default/page_views/snowplow_web_events.sql
@@ -15,7 +15,7 @@
 {{
     config(
         materialized='incremental',
-        sort='page_view_id',
+        sort=['page_view_id', 'collector_tstamp', 'domain_sessionid', 'domain_userid', 'dvce_created_tstamp'],
         dist='page_view_id',
         unique_key='page_view_id'
     )

--- a/models/page_views/optional/snowplow_web_ua_parser_context.sql
+++ b/models/page_views/optional/snowplow_web_ua_parser_context.sql
@@ -1,5 +1,10 @@
-
-{{ config(materialized='table', sort='page_view_id', dist='page_view_id') }}
+{{
+    config(
+        materialized='table',
+        sort='page_view_id',
+        dist='page_view_id'
+    )
+}}
 
 
 with ua_parser_context as (


### PR DESCRIPTION
Ok, I have digged quite a lot of time into the performance issues of the model. Here is my changes. I will comment what was investigated.

I have started with the query plan and checking amount of time model is building on subset of my prod data (about 410-430 seconds). I have to notice that Redshift creates quite a misleading plan, unfortunately. It does not reflect actual complexity of performing some parts of code and `analyse` does not help to fix this issue (at least in my setup). In my initial check of query plan I have notice such part:

```
->  XN Window  (cost=2000024289446.13..2000026736224.05 rows=81559264 width=352)
  Partition: domain_userid
  Order: dvce_created_tstamp
     ->  XN Sort  (cost=2000024289446.13..2000024493344.29 rows=81559264 width=352)
          Sort Key: domain_userid, dvce_created_tstamp
           ->  XN Network  (cost=1000011533028.59..1000013572010.19 rows=81559264 width=352)
             Distribute
             ->  XN Window  (cost=1000011533028.59..1000013572010.19 rows=81559264 width=352)
               Partition: domain_sessionid
               Order: dvce_created_tstamp
                ->  XN Sort  (cost=1000011533028.59..1000011736926.75 rows=81559264 width=352)
                  Sort Key: domain_sessionid, dvce_created_tstamp
                  ->  XN Network  (cost=0.00..815592.64 rows=81559264 width=352)
                   Distribute
                   ->  XN Seq Scan on snowplow_web_events  (cost=0.00..815592.64 rows=81559264 width=352)
```
Just take a look how dramatically cost increased due to sort and window functions. I started from that part of code. It is easy to find that it is reflecting this code: https://github.com/fishtown-analytics/snowplow/blob/master/macros/adapters/default/page_views/snowplow_web_events_internal_fixed.sql

I try to improve sorting keys in `snowplow_web_events` model and it bring a little bit performance in query plan and to actual performance in seconds (I have cuted down model building to 380s). I go further with the `snowplow_web_events_internal_fixed` and turned it to incremental build table instead of `ephemeral` one and get no significant improve of time and query plan. It looks very strange to me.

I have reverted `snowplow_web_events_internal_fixed` and go deeper with analysis of query log in `svl_query_summary` table. And notice very expensive scan of `snowplow_web_events`, unfortunately I can not find corresponding part in the query plan (all scans in plan looks quite cheap comparing to sort and window functions mentioned above). I have analyze all straight `select * from snowplow_web_events`. It leads me to introduction incremental processing of events with some backwindow as I mentioned in original idea of speed up:

```
with all_events as (

    select * from {{ ref('snowplow_web_events') }}
    {% if is_incremental() %}
    where collector_tstamp > (
        DATEADD('day', -1, (select coalesce(max(max_tstamp), '0001-01-01') from {{ this }}))
        )
    {% endif %}
),
...
```

It leads to cutting the total cost in plan quite a big number and I get about 200-220 seconds to build model in my setup. However, I still get a heavy scan of `snowplow_web_events`. I have the only idea how to identify the slow part of SQL - execute it manually part by part. It gives me a great result, I discovered that condition 
```
(a.useragent not {{ snowplow.similar_to('%(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a_archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt)%') }}
```
requires almost 90% of time within my dataset. Redshift documentation clearly points to the fact `similar to` is very expensive operation and it is better to replace it with `like` expression. I gave it a try and get speed up the code up to 10x times (about 15-18 seconds within my dataset). The strange thing is that it initial plan `similar to` cost quite cheap. Take a look:
```
->  XN Seq Scan on snowplow_web_events  (cost=0.00..2242879.76 rows=1 width=2228)
   Filter: ((((useragent)::text !~ '^(.*(.*(bot|crawl|slurp|spider|archiv|spinn|sniff|seo|audit|survey|pingdom|worm|capture|(browser|screen)shots|analyz|index|thumb|check|facebook|PingdomBot|PhantomJS|YandexBot|Twitterbot|a.archiver|facebookexternalhit|Bingbot|BingPreview|Googlebot|Baiduspider|360(Spider|User-agent)|semalt).*).*)$'::text) OR (useragent IS NULL)) AND (collector_tstamp > date_add('hour'::text, -1::bigint, $0)) AND ((COALESCE(br_type, 'unknown'::character varying))::text <> 'Bot/Crawler'::text) AND ((COALESCE(br_type, 'unknown'::character varying))::text <> 'Robot'::text) AND (((br_family)::text <> 'Robot/Spider'::text) OR (br_family IS NULL)) AND (domain_sessionidx > 0) AND (domain_userid IS NOT NULL))
```
Compare it to the cost of code `snowplow_web_events_internal_fixed`. Real result is different.
In total I get almost 10x performance increase within my prod data: from 1800 seconds to 200 seconds.