### PR TITLE
Rm unique test event_id in base events

### DIFF
--- a/models/base/schema.yml
+++ b/models/base/schema.yml
@@ -29,7 +29,6 @@ models:
           description: A UUID for each event
           tests:
               - not_null
-              - unique
               
         - name: txn_id
           description: Transaction ID set client-side, used to de-dupe records


### PR DESCRIPTION
Given:

* Snowplow's [post](https://snowplowanalytics.com/blog/2015/08/19/dealing-with-duplicate-event-ids/) on duplicate events
* Package modeling handles duplicate events in a [few](https://github.com/fishtown-analytics/snowplow/blob/master/macros/adapters/default/page_views/snowplow_web_events.sql#L144) [places](https://github.com/fishtown-analytics/snowplow/blob/master/macros/adapters/default/page_views/snowplow_web_page_context.sql), though I'd like to handle it differently in the future

I think it should be our position that analysts should not deduplicate their raw events before feeding them into the Snowplow package. This is an expensive operation, especially on a dataset this large, and it's not really in keeping with the paradigms of "bigger data" platforms (BQ et al).

To that end, we should disable the `unique` test on `snowplow_base_events.event_id`.