### PR TITLE
Change dist key to root_id from page_view_id

### DIFF
--- a/macros/adapters/default/page_views/snowplow_web_page_context.sql
+++ b/macros/adapters/default/page_views/snowplow_web_page_context.sql
@@ -18,7 +18,7 @@
     config(
         materialized='table',
         sort='page_view_id',
-        dist='page_view_id'
+        dist='root_id'
     )
 }}
 


### PR DESCRIPTION
This PR updates web page context dist key to root id. All subsequent models that join to web_page_context join on `root_id`, so this should spread the load across more nodes when joining.
