### PR TITLE
changes test errors to warnings

### DIFF
--- a/models/page_views/schema.yml
+++ b/models/page_views/schema.yml
@@ -28,6 +28,7 @@ models:
                 - relationships:
                     to: ref('snowplow_web_page_context')
                     field: page_view_id
+                    severity: warn
                     
     - name: snowplow_web_events_time
     
@@ -38,6 +39,7 @@ models:
                 - relationships:
                     to: ref('snowplow_web_page_context')
                     field: page_view_id
+                    severity: warn
                     
     - name: snowplow_web_events_scroll_depth
     
@@ -48,6 +50,7 @@ models:
                 - relationships:
                     to: ref('snowplow_web_page_context')
                     field: page_view_id
+                    severity: warn
 
     - name: snowplow_web_page_context
       tests:

--- a/models/sessions/schema.yml
+++ b/models/sessions/schema.yml
@@ -11,6 +11,7 @@ models:
             tests:
                 - not_null
                 - unique
+                    severity: warning
                     
           - name: user_custom_id
             description: Unique ID set by business, user_id

--- a/models/sessions/schema.yml
+++ b/models/sessions/schema.yml
@@ -10,7 +10,7 @@ models:
             description: A visit / session identifier
             tests:
                 - not_null
-                - unique
+                - unique: 
                     severity: warn
                     
           - name: user_custom_id

--- a/models/sessions/schema.yml
+++ b/models/sessions/schema.yml
@@ -11,7 +11,7 @@ models:
             tests:
                 - not_null
                 - unique
-                    severity: warning
+                    severity: warn
                     
           - name: user_custom_id
             description: Unique ID set by business, user_id


### PR DESCRIPTION
## Description and Motivation: 

- Changes 4 different test severities on the following relationship tests: 
- The relationship test from `snowplow_web_events` to `snowplow_web_page_context`
- The relationship test from `snowplow_web_events_scroll_depth` to `snowplow_web_page_context`
- The relationship test from `snowplow_web_events_time` to `snowplow_web_page_context`
- The uniqueness test on the `session_id` in `snowplow_sessions`.

- We find that there are often a **very small** number of failures in relationship tests in general, especially when it comes to event data like this.
- The number of warnings is not usually high enough to garner an `error`. Moving forward, it would be useful to have a dbt feature that gives us more flexibility around test severity. A corresponding issue has been opened in https://github.com/fishtown-analytics/dbt

## Related Issue in dbt core: 
- https://github.com/fishtown-analytics/dbt/issues/2219

## Files changed: 
- models/page_views/schema.yml
- models/sessions/schema.yml
