### PR TITLE
Refactor: optional contexts

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -28,9 +28,4 @@ vars:
 models:
   snowplow:
     base:
-      materialized: ephemeral
-      optional:
-        enabled: false
-    page_views:
-      optional:
-        enabled: false
+      +materialized: ephemeral

--- a/models/base/optional/snowplow_base_performance_timing_context.sql
+++ b/models/base/optional/snowplow_base_performance_timing_context.sql
@@ -1,2 +1,5 @@
+{{ config(
+    enabled=(var('snowplow:context:performance_timing') and is_adapter('default'))
+) }}
 
 select * from {{ var('snowplow:context:performance_timing') }}

--- a/models/base/optional/snowplow_base_useragent_context.sql
+++ b/models/base/optional/snowplow_base_useragent_context.sql
@@ -1,2 +1,5 @@
+{{ config(
+    enabled=(var('snowplow:context:useragent') and is_adapter('default'))
+) }}
 
 select * from {{ var('snowplow:context:useragent') }}

--- a/models/page_views/optional/snowplow_web_timing_context.sql
+++ b/models/page_views/optional/snowplow_web_timing_context.sql
@@ -75,9 +75,13 @@ prep as (
       and pt.load_event_end is not null -- zero is acceptable
 
       -- remove rare outliers (Unix timestamp is more than twice what it should be)
-      and datediff(d, pt.root_tstamp, (timestamp 'epoch' + pt.response_end/1000 * interval '1 second ')) < 365
-      and datediff(d, pt.root_tstamp, (timestamp 'epoch' + pt.unload_event_start/1000 * interval '1 second ')) < 365
-      and datediff(d, pt.root_tstamp, (timestamp 'epoch' + pt.unload_event_end/1000 * interval '1 second ')) < 365
+      
+      {% set ts_columns = ['pt.response_end', 'pt.unload_event_start', 'pt.unload_event_end'] %}
+      {% for ts_column in ts_columns %}
+      
+      and {{ dbt_utils.datediff(dbt_utils.dateadd('millisecond', ts_column, "'1970-01-01'"), 'pt.root_tstamp', 'day') }} < 365
+      
+      {% endfor %}
 
 ),
 

--- a/models/page_views/optional/snowplow_web_timing_context.sql
+++ b/models/page_views/optional/snowplow_web_timing_context.sql
@@ -3,7 +3,8 @@
     config(
         materialized='table',
         sort='page_view_id',
-        dist='page_view_id'
+        dist='page_view_id',
+        enabled=(var('snowplow:context:performance_timing') and is_adapter('default'))
     ) 
 }}
 

--- a/models/page_views/optional/snowplow_web_ua_parser_context.sql
+++ b/models/page_views/optional/snowplow_web_ua_parser_context.sql
@@ -2,7 +2,8 @@
     config(
         materialized='table',
         sort='page_view_id',
-        dist='page_view_id'
+        dist='page_view_id',
+        enabled=(var('snowplow:context:useragent') and is_adapter('default'))
     )
 }}
 


### PR DESCRIPTION
## Description & motivation

* Use the `'snowplow:context:useragent'` and `snowplow:context:performance_timing'` variables to dynamically enable or disable the optional models, rather than disabling them by default in `dbt_project.yml`. (They're currently only implemented for the default adapter.)

### snowplow_web_time_context

* Make logic cross-db compatible by replacing pg/redshift date functions with ones from `dbt_utils`
* ~**Breaking change:** Change the filtering logic to allow for null values of `domain_lookup_start`, `domain_lookup_end`, and `secure_connection_start`. This a purely empirical observation: these values are always null for performance tracking on `cloud.getdbt.com`.~ Disregard, I did something tremendously silly when I was modeling this data.

~The code for this model originally comes from the [Snowplow web model](https://github.com/snowplow/snowplow-web-data-model/blob/master/redshift/sql/01-page-views/05-timing-context.sql), and this [Discourse post](https://discourse.snowplowanalytics.com/t/measuring-page-load-times-with-the-performance-timing-context-tutorial/100) describes it in detail. Both are >4 years old, and I wouldn't be surprised if some of the recommendations are out of date.~

## Checklist
- [x] I have verified that these changes work locally
