### PR TITLE
Remove duplicated unique test

### DIFF
--- a/models/page_views/schema.yml
+++ b/models/page_views/schema.yml
@@ -50,8 +50,10 @@ models:
 
     - name: snowplow_web_page_context
       tests:
-          - unique:
-              column_name: "concat(page_view_id, root_id)"
+        - dbt_utils.unique_combination_of_columns:
+            combination_of_columns:
+              - page_view_id
+              - root_id
     
       columns:
           - name: page_view_id

--- a/models/page_views/schema.yml
+++ b/models/page_views/schema.yml
@@ -16,10 +16,6 @@ models:
           - name: domain_sessionid
             tests:
                 - not_null
-                        
-          - name: domain_sessionid
-            tests:
-                - not_null
                 
           - name: page_view_id
             tests:


### PR DESCRIPTION
Remove duplicated test. This will start raising an error in dbt Core v1.0.0. This change is backwards-compatible and can go into a patch release.

We'll want to swing back, here and in other packages, to rename `dbt_project.yml` configs so as to silence deprecation warnings. Those will be backwards-incompatible and will require minor version releases.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
