### PR TITLE
Upversion dbt-utils dependency accounting for features moved to core

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 #settings specifically for this models directory
 #config other dbt settings within ~/.dbt/profiles.yml
 name: 'snowplow'
-version: '0.13.0'
+version: '0.14.0'
 config-version: 2
 
 model-paths: ["models"]

--- a/models/page_views/default/snowplow_page_views.sql
+++ b/models/page_views/default/snowplow_page_views.sql
@@ -24,11 +24,11 @@ with all_events as (
     {% if is_incremental() %}
     
         where collector_tstamp >
-            {{dbt_utils.dateadd(
+            {{ dbt.dateadd(
                 'day',
                 -1 * var('snowplow:page_view_lookback_days'),
                 get_start_ts(this, 'max_tstamp')
-            )}}
+            ) }}
     
     {% endif %}
 
@@ -220,17 +220,17 @@ prep as (
             d.os_patch as os_build_version,
             d.device_family as device,
         {% else %}
-            cast(null as {{ dbt_utils.type_string() }}) as browser,
+            cast(null as {{ dbt.type_string() }}) as browser,
             a.br_family as browser_name,
             a.br_name as browser_major_version,
             a.br_version as browser_minor_version,
-            cast(null as {{ dbt_utils.type_string() }}) as browser_build_version,
+            cast(null as {{ dbt.type_string() }}) as browser_build_version,
             a.os_family as os,
             a.os_name as os_name,
-            cast(null as {{ dbt_utils.type_string() }}) as os_major_version,
-            cast(null as {{ dbt_utils.type_string() }}) as os_minor_version,
-            cast(null as {{ dbt_utils.type_string() }}) as os_build_version,
-            cast(null as {{ dbt_utils.type_string() }}) as device,
+            cast(null as {{ dbt.type_string() }}) as os_major_version,
+            cast(null as {{ dbt.type_string() }}) as os_minor_version,
+            cast(null as {{ dbt.type_string() }}) as os_build_version,
+            cast(null as {{ dbt.type_string() }}) as device,
         {% endif %}
 
         c.br_viewwidth as browser_window_width,

--- a/models/page_views/optional/snowplow_web_timing_context.sql
+++ b/models/page_views/optional/snowplow_web_timing_context.sql
@@ -79,7 +79,7 @@ prep as (
       {% set ts_columns = ['pt.response_end', 'pt.unload_event_start', 'pt.unload_event_end'] %}
       {% for ts_column in ts_columns %}
       
-      and {{ dbt_utils.datediff('pt.root_tstamp', dbt_utils.dateadd('millisecond', ts_column, "'1970-01-01'"), 'day') }} < 365
+      and {{ dbt.datediff('pt.root_tstamp', dbt.dateadd('millisecond', ts_column, "'1970-01-01'"), 'day') }} < 365
       
       {% endfor %}
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.9.0", "<0.10.0"]
+    version: [">=0.9.0", "<2.0.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 0.9.5
+    version: [">=0.9.0", "<0.10.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: 0.9.5


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Upversion `dbt-utils` dependency to <0.9 and >2.0 and account for cross-database macros that were migrated from dbt-utils to dbt-core.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
