### PR TITLE
PODC-787: Remove Ephemeral Materialization to Ensure Snowplow Models Get Deployed

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -25,7 +25,3 @@ vars:
   'snowplow:pass_through_columns': []
   'snowplow:page_view_lookback_days': 1
 
-models:
-  snowplow:
-    base:
-      +materialized: ephemeral

--- a/models/page_views/bigquery/snowplow_page_views.sql
+++ b/models/page_views/bigquery/snowplow_page_views.sql
@@ -120,56 +120,18 @@ page_views as (
         when refr_medium = 'unknown' then 'other'
         else refr_medium
       end as medium,
-      refr_source as source,
-      refr_term as term
+      refr_source as source
     ) as referer,
 
     struct(
-      mkt_medium as medium,
-      mkt_source as source,
-      mkt_term as term,
-      mkt_content as content,
-      mkt_campaign as campaign,
-      mkt_clickid as click_id,
-      mkt_network as network
+      mkt_source as source
     ) as marketing,
 
     struct(
-      user_ipaddress as ip_address,
-      ip_isp as isp,
-      ip_organization as organization,
-      ip_domain as domain,
-      ip_netspeed as net_speed
+      user_ipaddress as ip_address
     ) as ip,
 
-    struct(
-      geo_city as city,
-      geo_country as country,
-      geo_latitude as latitude,
-      geo_longitude as longitude,
-      geo_region as region,
-      geo_region_name as region_name,
-      geo_timezone as timezone,
-      geo_zipcode as zipcode
-    ) as geo,
-
-    struct(
-      os_family as family,
-      os_manufacturer as manufacturer,
-      os_name as name,
-      os_timezone as timezone
-    ) as os,
-
     br_lang as browser_language,
-
-    -- TODO : useragent
-    -- TODO : perf_timing
-
-    struct(
-        br_renderengine as browser_engine,
-        dvce_type as type,
-        dvce_ismobile as is_mobile
-    ) as device
     
     {%- if var('snowplow:pass_through_columns') | length > 0 %}
     , struct(
@@ -179,7 +141,6 @@ page_views as (
 
   from events
   where event = 'page_view'
-    and (br_family != 'Robot/Spider' or br_family is null)
     and (
         {% set bad_agents_psv = bot_any()|join('|') %}
         not regexp_contains(LOWER(useragent), '^.*({{bad_agents_psv}}).*$')

--- a/models/page_views/default/snowplow_web_page_context.sql
+++ b/models/page_views/default/snowplow_web_page_context.sql
@@ -24,7 +24,7 @@ prep as (
         root_id,
         -- The context table doesn't have an ID besides `root_id`, so
         -- we need a unique reference to the context
-        __sdc_primary_key as page_view_id
+        id as page_view_id
 
     from web_page_context
     group by 1,2

--- a/models/page_views/default/snowplow_web_page_context.sql
+++ b/models/page_views/default/snowplow_web_page_context.sql
@@ -22,7 +22,9 @@ prep as (
 
     select
         root_id,
-        id as page_view_id
+        -- The context table doesn't have an ID besides `root_id`, so
+        -- we need a unique reference to the context
+        __sdc_primary_key as page_view_id
 
     from web_page_context
     group by 1,2

--- a/models/sessions/bigquery/snowplow_sessions_tmp.sql
+++ b/models/sessions/bigquery/snowplow_sessions_tmp.sql
@@ -6,8 +6,7 @@
             'data_type': 'timestamp'
         },
         unique_key='session_id',
-        cluster_by='session_id',
-        enabled=is_adapter('bigquery')
+        cluster_by='session_id'
     )
 }}
 
@@ -85,12 +84,9 @@ sessions as (
     first_page_view.user_custom_id,
     first_page_view.user_snowplow_domain_id,
     first_page_view.user_snowplow_crossdomain_id,
-
     first_page_view.session_id,
     first_page_view.session_index,
-
     first_page_view.app_id,
-
     timing.session_start,
     timing.session_end,
     array_length(all_pageviews) as count_page_views,
@@ -115,13 +111,10 @@ sessions as (
 
     first_page_view.referer as referer,
     first_page_view.marketing as marketing,
-    first_page_view.geo as geo,
     first_page_view.ip as ip,
     first_page_view.browser as browser,
-    first_page_view.os as os,
-    first_page_view.device as device,
     
-    {% if var('snowplow:pass_through_columns') | length > 0 %}
+    {% if var('snowplow_pass_through_columns', []) | length > 0 %}
     first_page_view.custom as first_custom,
     exit_page_view.custom as last_custom,
     {% endif %}

--- a/models/sessions/bigquery/snowplow_sessions_tmp.sql
+++ b/models/sessions/bigquery/snowplow_sessions_tmp.sql
@@ -85,12 +85,9 @@ sessions as (
     first_page_view.user_custom_id,
     first_page_view.user_snowplow_domain_id,
     first_page_view.user_snowplow_crossdomain_id,
-
     first_page_view.session_id,
     first_page_view.session_index,
-
     first_page_view.app_id,
-
     timing.session_start,
     timing.session_end,
     array_length(all_pageviews) as count_page_views,
@@ -115,13 +112,10 @@ sessions as (
 
     first_page_view.referer as referer,
     first_page_view.marketing as marketing,
-    first_page_view.geo as geo,
     first_page_view.ip as ip,
     first_page_view.browser as browser,
-    first_page_view.os as os,
-    first_page_view.device as device,
     
-    {% if var('snowplow:pass_through_columns') | length > 0 %}
+    {% if var('snowplow_pass_through_columns', []) | length > 0 %}
     first_page_view.custom as first_custom,
     exit_page_view.custom as last_custom,
     {% endif %}


### PR DESCRIPTION
## Description
This PR fixes some odd issues we've recently observed with our dbt tests, see: 

- https://gitlab.com/packback/data-engineering/-/pipelines/928147114
- https://airflow.packback.co/log?dag_id=ci_dbt_deployments&task_id=test_dbt_models&execution_date=2023-07-11T14%3A50%3A00%2B00%3A00&map_index=-1

This package effectively acts as library code for our dbt project that encapsulates much of the necessary complexity to transform raw snowplow events into useful tables like `page_views` and `sessions`. As such, the models that are created by this package are not explicitly assigned a dataset and get defaulted to `should_not_be_used` -- this is _mostly_ fine since we have no direct use for any of these models and can simply let them get deployed in the background without being assigned to a particular dataset. Our `models/snowplow_events/` dataset will automatically build from these package-specific tables without needing to assign them to a dataset. 

The current configuration specifies an `ephemeral` materialization strategy. This may seem fine for our purposes but has an unexpected complication: our unit tests expect that the package-specific tables exist in the `should_not_be_used` dataset and an ephemeral reference is not acceptable (if it can't find the upstream tables, it will fail). See: https://github.com/EqualExperts/dbt-unit-testing/issues/149 -- other folks have also seemed to notice this is not supported.

## Testing
I tested this changes by manually modifying the package code locally in `dbt_config/dbt_packages/snowplow/dbt_project.yml` and then running: 

- `dbt run -m snowplow`
- `dbt test -m tests/unit/snowplow_events__page_views_tagged_pages.sql` 

After re-deploying the Snowplow models and re-running the unit tests, the issue appeared to be resolved.

![image](https://github.com/dbt-labs/snowplow/assets/50755445/497f5b4e-71f1-43fb-9669-c99ba06cdf04)

![image](https://github.com/dbt-labs/snowplow/assets/50755445/27dfcce0-98e2-4bb8-a38a-7d90444e12ba)

